### PR TITLE
Редирект на страницу пользователя для залогиненных

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -6,6 +6,9 @@ class HomeController extends Controller
 {
     public function index()
     {
+        if (auth()->check()) {
+            return redirect()->route('social.show', ['id' => auth()->id()]);
+        }
         return view('home');
     }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,8 +1,8 @@
 @extends('layouts.terminal')
 @section('content')
     <div class="terminal-window-home">
-        <div class="terminal-window-bar-home">
-            <span class="terminal-window-btn-home close"></span>
+            <div class="terminal-window-bar-home">
+                <span class="terminal-window-btn-home close"></span>
             <span class="terminal-window-btn-home minimize"></span>
             <span class="terminal-window-btn-home zoom"></span>
             <span class="terminal-title-home">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,12 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    if (Auth::check()) {
-        return redirect()->route('social.index');
-    }
-    return view('home');
-})->name('home');
+Route::get('/', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
 
 
 Route::get('/social/{id}', [App\Http\Controllers\SocialController::class, 'show'])


### PR DESCRIPTION
## Что сделано

- Главная страница (`/`) теперь доступна только для гостей.
- Если пользователь авторизован, происходит автоматический редирект на его личную страницу (`/social/{id}`).
- Для гостей отображается прежний терминальный интерфейс с кнопками входа и регистрации.