### PR TITLE
Улучшение визуала на странице чата

### DIFF
--- a/resources/css/chat.css
+++ b/resources/css/chat.css
@@ -160,28 +160,33 @@
 
 .terminal-input-chat {
     flex-grow: 1;
-    padding: 0.75rem 1rem;
-    border: none;
-    border-radius: 12px;
-    background-color: #2c2c2c;
+    padding: 0.9rem 1.2rem;
+    border: 2px solid #232b2b;
+    border-radius: 16px;
+    background-color: #232b2b;
     color: white;
-    font-size: 1rem;
+    font-size: 1.05rem;
     outline: none;
-    transition: background-color 0.2s;
+    transition: border-color 0.2s, background-color 0.2s;
+}
+
+.terminal-input-chat:focus {
+    background-color: #262f2f;
+    border-color: var(--primary-chat);
 }
 
 .terminal-input-chat::placeholder {
     color: #aaa;
-}
-
-.terminal-input-chat:focus {
-    background-color: #333;
+    opacity: 0.7;
 }
 
 .chat-contact {
+    position: relative;
+    min-height: 68px;
+    padding: 1.1rem 1rem 1.1rem 1rem;
+    margin-bottom: 8px;
     transition: background-color 0.2s;
     border-radius: 8px;
-    padding: 0.5rem;
 }
 
 .chat-contact {
@@ -192,7 +197,6 @@
     gap: 0.75rem;
     cursor: pointer;
     transition: background 0.2s;
-    position: relative;
 }
 
 .chat-contact:hover {
@@ -285,6 +289,17 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+}
+
+.contact-lastmsg-time {
+    position: absolute;
+    right: 16px;
+    bottom: 10px;
+    color: var(--text-tertiary);
+    font-size: 0.92em;
+    opacity: 0.8;
+    font-family: 'Fira Mono', 'Courier New', Courier, monospace;
+    pointer-events: none;
 }
 
 .contact-time {
@@ -451,11 +466,15 @@
 .message-row.received .message-content {
     background: var(--surface-light);
     color: var(--text-primary);
+    border: 1.5px solid var(--border-primary);
+    padding: 0.85rem 1.2rem;
 }
 
 .message-row.sent .message-content {
-    background: var(--primary-chat);
-    color: var(--surface-dark);
+    background: #009e50;
+    color: #fff;
+    border: none;
+    padding: 0.85rem 1.2rem;
 }
 
 .message-header {
@@ -586,24 +605,25 @@
     background: none;
     border: none;
     cursor: pointer;
-    padding: 0.25rem;
-    transition: transform 0.2s;
+    padding: 0.4rem;
+    border-radius: 50%;
+    transition: background-color 0.2s, transform 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.attach-button:hover svg {
-    transform: scale(1.1);
+.attach-button:hover {
+    background-color: rgba(0, 230, 118, 0.13);
+    transform: scale(1.12);
+}
+
+.attach-button:active {
+    background-color: rgba(0, 230, 118, 0.22);
 }
 
 .attach-button svg {
     transition: transform 0.2s;
-}
-
-.attach-button:hover {
-    background-color: rgba(0, 230, 118, 0.1);
-}
-
-.attach-button:active {
-    background-color: rgba(0, 230, 118, 0.2);
 }
 
 .terminal-sidebar-message {
@@ -724,4 +744,31 @@
     height: 100%;
     z-index: 2;
     border-radius: 12px;
+}
+
+.date-divider {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 1.2rem 0 0.8rem 0;
+    width: 100%;
+    font-size: 0.92rem;
+    color: var(--text-tertiary);
+    font-family: 'Fira Mono', 'Courier New', Courier, monospace;
+    opacity: 0.85;
+}
+.date-divider-line {
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, #444 60%, transparent);
+    margin: 0 10px;
+}
+.date-divider-text {
+    white-space: nowrap;
+    padding: 0 8px;
+    font-size: 0.92em;
+    color: var(--text-tertiary);
+    background: var(--surface-medium);
+    border-radius: 6px;
+    opacity: 0.95;
 }

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -93,7 +93,24 @@
 
                         <div class="messages chat-messages" id="chat-messages">
                             @if(isset($messages) && count($messages))
+                            @php $prevDate = null; @endphp
                             @foreach($messages as $message)
+                                @php
+                                    $msgDate = $message->created_at->format('Y-m-d');
+                                @endphp
+                                @if($prevDate !== $msgDate)
+                                    <div class="date-divider">
+                                        <span class="date-divider-line"></span>
+                                        <span class="date-divider-text">
+                                            @if($msgDate === now()->format('Y-m-d')) Сегодня
+                                            @elseif($msgDate === now()->subDay()->format('Y-m-d')) Вчера
+                                            @else {{ \Carbon\Carbon::parse($msgDate)->translatedFormat('d F Y') }}
+                                            @endif
+                                        </span>
+                                        <span class="date-divider-line"></span>
+                                    </div>
+                                    @php $prevDate = $msgDate; @endphp
+                                @endif
                                 @include('messages.receive', [
                                     'message' => $message,
                                     'authId' => auth()->id()


### PR DESCRIPTION
## Основные изменения

### 1. Шапка чата (current-contact)
- Индикатор онлайн/оффлайн -теперь только точка на аватарке, без текста.
- Размер и отступы аватарки приведены к единому виду с остальными элементами.

### 2. Контраст сообщений
- Отправленные сообщения: поменяли цвет - они стали чуть более насыщенными зелеными.
- Увеличен внутренний отступ для “пузырей” сообщений.

### 3. Визуальное разделение по датам
- Между сообщениями с разной датой добавлен разделитель: тонкая линия с датой по центру (“Сегодня”, “Вчера” или полная дата).

### 4. Время сообщений в sidebar
- Время последнего сообщения теперь отображается в правом нижнем углу блока контакта, серым и менее заметным шрифтом.
- Исправлены паддинги и высота блоков контактов для лучшей читаемости и отделения друг от друга.
